### PR TITLE
Workaround for apt security repository info changes

### DIFF
--- a/packer-template.json
+++ b/packer-template.json
@@ -27,7 +27,7 @@
       "type": "shell",
       "inline": [
         "sudo cp -a /etc/chrony/chrony.conf /var/tmp/chrony.conf.google",
-        "sudo apt-get update",
+        "sudo apt-get --allow-releaseinfo-change update",
         "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends etckeeper",
         "sudo DEBIAN_FRONTEND=noninteractive apt-get remove -y --purge chrony unattended-upgrades"
       ],


### PR DESCRIPTION
`apt-get update` got following error because debian 10 "buster" has been released.

```
    googlecompute: Get:1 http://deb.debian.org/debian buster InRelease [118 kB]
    googlecompute: Get:2 http://packages.cloud.google.com/apt google-compute-engine-buster-stable InRelease [3838 B]
    googlecompute: Get:3 http://packages.cloud.google.com/apt cloud-sdk-buster InRelease [6372 B]
    googlecompute: Hit:4 http://packages.cloud.google.com/apt google-cloud-packages-archive-keyring-buster InRelease
    googlecompute: Get:5 http://packages.cloud.google.com/apt cloud-sdk-buster/main amd64 Packages [77.9 kB]
    googlecompute: Reading package lists...
==> googlecompute: E: Repository 'http://deb.debian.org/debian buster InRelease' changed its 'Suite' value from 'testing' to 'stable'
```

see also:
- https://twitter.com/debian/status/1147896073383366656
