### PR TITLE
block project-wide public SSH keys

### DIFF
--- a/packer-template.json
+++ b/packer-template.json
@@ -15,7 +15,10 @@
     "image_name": "debian-sid-v{{isotime \"20060102-150405\"}}",
     "image_family": "debian-sid",
     "image_description": "Debian sid (source image: {{user `source_image`}})",
-    "ssh_username": "packer"
+    "ssh_username": "packer",
+    "metadata": {
+      "block-project-ssh-keys": "TRUE"
+    }
   }],
   "provisioners":[
     {


### PR DESCRIPTION
https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys?hl=en#block-project-keys