### PR TITLE
Workaround: Upgrade libc6 with APT::Immediate-Configure=false before dist-upgrade to fix build error

### DIFF
--- a/packer-template.json
+++ b/packer-template.json
@@ -60,6 +60,7 @@
         "sudo install -m 644 -o root -g root /tmp/sources.list /etc/apt/sources.list",
         "sudo DEBIAN_FRONTEND=noninteractive etckeeper commit 'apt: updated to sid'",
         "sudo apt-get update",
+        "sudo DEBIAN_FRONTEND=noninteractive apt-get install libc6 -o APT::Immediate-Configure=false -y --no-install-recommends",
         "sudo DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y --no-install-recommends --auto-remove --purge",
         "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y chrony",
         "sudo cp -a /var/tmp/chrony.conf.google /etc/chrony/chrony.conf",


### PR DESCRIPTION
```
==> googlecompute: E: Could not configure 'libc6:amd64'.
==> googlecompute: E: Could not perform immediate configuration on 'libnss-nis:amd64'. Please see man 5 apt.conf under APT::Immediate-Configure for details. (2)
```